### PR TITLE
bump log4j to 2.17.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,22 +50,22 @@
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-core</artifactId>
-      <version>2.16.0</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-api</artifactId>
-      <version>2.16.0</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-slf4j-impl</artifactId>
-      <version>2.16.0</version>
+      <version>2.17.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
       <artifactId>log4j-1.2-api</artifactId>
-      <version>2.16.0</version>
+      <version>2.17.0</version>
     </dependency>
   </dependencies>
   <build>


### PR DESCRIPTION
bump log4j to v2.17.0 to address https://nvd.nist.gov/vuln/detail/CVE-2021-45105
